### PR TITLE
correcting if statement

### DIFF
--- a/DashticzApp.qml
+++ b/DashticzApp.qml
@@ -68,7 +68,7 @@ App {
 					
 					var temp = JSON.parse(settingsFile.responseText);
 					for (var setting in settings) {
-						if (!temp[setting])  { temp[setting] = settings[setting]; } // use default if no saved setting exists
+						if (temp[setting] === undefined)  { temp[setting] = settings[setting]; } // use default if no saved setting exists
 					}
 					settings = temp;
 					tileIDXList = settings.domoticzTileIDX.split(',')


### PR DESCRIPTION
The proposed change fixed loading boolean configs. With the previous if statement when a saved boolean setting was 'false' the resulst of the if statement was false, resulting in the default setting to be loaded (which could be 'true').